### PR TITLE
test: 순수 함수 단위 테스트 90개 추가

### DIFF
--- a/src/components/common/__tests__/saju-utils.test.ts
+++ b/src/components/common/__tests__/saju-utils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest"
+import { hanjaLabel, toDate, formatBirthTime } from "../saju-utils"
+
+describe("hanjaLabel", () => {
+  it("천간/지지 한자를 조합한다", () => {
+    expect(hanjaLabel("갑", "자")).toBe("甲子(갑자)")
+    expect(hanjaLabel("을", "축")).toBe("乙丑(을축)")
+  })
+
+  it("맵에 없는 글자는 원본을 사용한다", () => {
+    expect(hanjaLabel("X", "Y")).toBe("XY(XY)")
+  })
+
+  it("천간만 맵에 있는 경우", () => {
+    expect(hanjaLabel("병", "Z")).toBe("丙Z(병Z)")
+  })
+})
+
+describe("toDate", () => {
+  it("Date 객체를 그대로 반환한다", () => {
+    const d = new Date("2024-01-15")
+    expect(toDate(d)).toBe(d)
+  })
+
+  it("문자열을 Date 객체로 변환한다", () => {
+    const result = toDate("2024-01-15T00:00:00.000Z")
+    expect(result).toBeInstanceOf(Date)
+    expect(result.toISOString()).toBe("2024-01-15T00:00:00.000Z")
+  })
+})
+
+describe("formatBirthTime", () => {
+  it("시간과 분을 포맷한다", () => {
+    expect(formatBirthTime(9, 30)).toBe("09:30")
+    expect(formatBirthTime(14, 5)).toBe("14:05")
+  })
+
+  it("시간이 null이면 '미상'을 반환한다", () => {
+    expect(formatBirthTime(null, 30)).toBe("미상")
+    expect(formatBirthTime(undefined, 0)).toBe("미상")
+  })
+
+  it("분이 null이면 0으로 처리한다", () => {
+    expect(formatBirthTime(8, null)).toBe("08:00")
+    expect(formatBirthTime(0, undefined)).toBe("00:00")
+  })
+
+  it("자정(0시)도 올바르게 처리한다", () => {
+    expect(formatBirthTime(0, 0)).toBe("00:00")
+  })
+})

--- a/src/features/analysis/compatibility/__tests__/compatibility-scoring.test.ts
+++ b/src/features/analysis/compatibility/__tests__/compatibility-scoring.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest"
+import { calculateCompatibilityScore } from "../compatibility-scoring"
+import type { TeacherAnalysisData, StudentAnalysisData } from "../compatibility-scoring"
+
+describe("calculateCompatibilityScore", () => {
+  it("분석 데이터가 전혀 없어도 에러 없이 점수를 반환한다", () => {
+    const teacher: TeacherAnalysisData = {}
+    const student: StudentAnalysisData = {}
+    const result = calculateCompatibilityScore(teacher, student)
+
+    expect(result.overall).toBeGreaterThanOrEqual(0)
+    expect(result.overall).toBeLessThanOrEqual(100)
+    expect(result.breakdown).toBeDefined()
+    expect(result.reasons.length).toBeGreaterThan(0)
+  })
+
+  it("담당 학생 수가 적으면 loadBalance 점수가 높다", () => {
+    const result = calculateCompatibilityScore(
+      { currentLoad: 5 },
+      {}
+    )
+    expect(result.breakdown.loadBalance).toBe(15)
+  })
+
+  it("담당 학생 수가 많으면 loadBalance 점수가 낮다", () => {
+    const result = calculateCompatibilityScore(
+      { currentLoad: 35 },
+      {}
+    )
+    expect(result.breakdown.loadBalance).toBe(0)
+  })
+
+  it("overall은 breakdown 합산과 일치한다", () => {
+    const result = calculateCompatibilityScore({}, {})
+    const sum =
+      result.breakdown.mbti +
+      result.breakdown.learningStyle +
+      result.breakdown.saju +
+      result.breakdown.name +
+      result.breakdown.loadBalance
+    expect(result.overall).toBe(sum)
+  })
+
+  it("MBTI 데이터가 있으면 mbti breakdown이 0보다 크다", () => {
+    const teacher: TeacherAnalysisData = {
+      mbti: { E: 70, I: 30, S: 60, N: 40, T: 55, F: 45, J: 65, P: 35 },
+    }
+    const student: StudentAnalysisData = {
+      mbti: { E: 65, I: 35, S: 50, N: 50, T: 40, F: 60, J: 70, P: 30 },
+    }
+    const result = calculateCompatibilityScore(teacher, student)
+    expect(result.breakdown.mbti).toBeGreaterThan(0)
+    expect(result.breakdown.learningStyle).toBeGreaterThan(0)
+  })
+})

--- a/src/features/analysis/mbti/__tests__/mbti-scoring.test.ts
+++ b/src/features/analysis/mbti/__tests__/mbti-scoring.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest"
+import { calculateProgress, scoreMbti } from "../mbti-scoring"
+import type { Question } from "../mbti-scoring"
+
+describe("calculateProgress", () => {
+  it("진행률을 계산한다", () => {
+    const responses = { "1": 3, "2": 4, "3": 2 }
+    expect(calculateProgress(responses, 10)).toEqual({
+      answeredCount: 3,
+      totalQuestions: 10,
+      percentage: 30,
+    })
+  })
+
+  it("전부 응답하면 100%이다", () => {
+    const responses = { "1": 3, "2": 4 }
+    expect(calculateProgress(responses, 2).percentage).toBe(100)
+  })
+
+  it("응답이 없으면 0%이다", () => {
+    expect(calculateProgress({}, 10).percentage).toBe(0)
+  })
+})
+
+describe("scoreMbti", () => {
+  const questions: Question[] = [
+    { id: 1, dimension: "EI", pole: "E", text: "Q1", description: "" },
+    { id: 2, dimension: "EI", pole: "I", text: "Q2", description: "" },
+    { id: 3, dimension: "SN", pole: "S", text: "Q3", description: "" },
+    { id: 4, dimension: "SN", pole: "N", text: "Q4", description: "" },
+    { id: 5, dimension: "TF", pole: "T", text: "Q5", description: "" },
+    { id: 6, dimension: "TF", pole: "F", text: "Q6", description: "" },
+    { id: 7, dimension: "JP", pole: "J", text: "Q7", description: "" },
+    { id: 8, dimension: "JP", pole: "P", text: "Q8", description: "" },
+  ]
+
+  it("E > I → E타입으로 판정한다", () => {
+    const responses = {
+      "1": 5, "2": 2, // E=5, I=2
+      "3": 4, "4": 3, // S=4, N=3
+      "5": 1, "6": 5, // T=1, F=5
+      "7": 4, "8": 3, // J=4, P=3
+    }
+    const result = scoreMbti(responses, questions)
+    expect(result.mbtiType).toBe("ESFJ")
+    expect(result.scores.e).toBe(5)
+    expect(result.scores.i).toBe(2)
+  })
+
+  it("I > E → I타입으로 판정한다", () => {
+    const responses = {
+      "1": 2, "2": 5, // I
+      "3": 2, "4": 5, // N
+      "5": 5, "6": 2, // T
+      "7": 2, "8": 5, // P
+    }
+    expect(scoreMbti(responses, questions).mbtiType).toBe("INTP")
+  })
+
+  it("동점이면 첫 번째 극(E,S,T,J)으로 판정한다", () => {
+    const responses = {
+      "1": 3, "2": 3, // E=I → E
+      "3": 3, "4": 3, // S=N → S
+      "5": 3, "6": 3, // T=F → T
+      "7": 3, "8": 3, // J=P → J
+    }
+    expect(scoreMbti(responses, questions).mbtiType).toBe("ESTJ")
+  })
+
+  it("퍼센티지 합이 100이다", () => {
+    const responses = { "1": 5, "2": 2, "3": 4, "4": 3, "5": 1, "6": 5, "7": 4, "8": 3 }
+    const result = scoreMbti(responses, questions)
+    expect(result.percentages.E + result.percentages.I).toBe(100)
+    expect(result.percentages.S + result.percentages.N).toBe(100)
+    expect(result.percentages.T + result.percentages.F).toBe(100)
+    expect(result.percentages.J + result.percentages.P).toBe(100)
+  })
+
+  it("응답하지 않은 질문은 무시한다", () => {
+    const responses = { "1": 5, "3": 4, "5": 3, "7": 2 }
+    const result = scoreMbti(responses, questions)
+    expect(result.scores.e).toBe(5)
+    expect(result.scores.i).toBe(0)
+  })
+})

--- a/src/features/analysis/name/__tests__/name-numerology.test.ts
+++ b/src/features/analysis/name/__tests__/name-numerology.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest"
+import {
+  splitKoreanName,
+  calculateNameNumerology,
+  generateNameInterpretation,
+} from "../name-numerology"
+
+describe("splitKoreanName", () => {
+  it("2글자 이름을 분리한다 (성 1 + 이름 1)", () => {
+    const result = splitKoreanName("김철")
+    expect(result).toEqual({
+      surname: "김",
+      givenName: "철",
+      surnameLength: 1,
+      givenNameLength: 1,
+    })
+  })
+
+  it("3글자 이름을 분리한다 (성 1 + 이름 2)", () => {
+    const result = splitKoreanName("김철수")
+    expect(result).toEqual({
+      surname: "김",
+      givenName: "철수",
+      surnameLength: 1,
+      givenNameLength: 2,
+    })
+  })
+
+  it("복성을 인식한다 (남궁)", () => {
+    const result = splitKoreanName("남궁민")
+    expect(result).toEqual({
+      surname: "남궁",
+      givenName: "민",
+      surnameLength: 2,
+      givenNameLength: 1,
+    })
+  })
+
+  it("복성 + 이름 2글자 (4글자)", () => {
+    const result = splitKoreanName("제갈공명")
+    expect(result).toEqual({
+      surname: "제갈",
+      givenName: "공명",
+      surnameLength: 2,
+      givenNameLength: 2,
+    })
+  })
+
+  it("1글자 이름은 null을 반환한다", () => {
+    expect(splitKoreanName("김")).toBeNull()
+  })
+
+  it("5글자 이상 이름은 null을 반환한다", () => {
+    expect(splitKoreanName("김나라사랑해")).toBeNull()
+  })
+})
+
+describe("calculateNameNumerology", () => {
+  it("한자 없으면 missing-hanja 상태를 반환한다", () => {
+    const result = calculateNameNumerology({ name: "김철수" })
+    expect(result.status).toBe("missing-hanja")
+  })
+
+  it("이름 길이가 범위 밖이면 invalid-name을 반환한다", () => {
+    const result = calculateNameNumerology({ name: "김", hanjaName: "金" })
+    expect(result.status).toBe("invalid-name")
+  })
+
+  it("한자와 이름 길이가 다르면 missing-hanja를 반환한다", () => {
+    const result = calculateNameNumerology({ name: "김철수", hanjaName: "金哲" })
+    expect(result.status).toBe("missing-hanja")
+  })
+
+  it("유효한 한자 이름으로 성명학을 계산한다", () => {
+    // 金(8) + 哲(10) + 洙(10)
+    const result = calculateNameNumerology({ name: "김철수", hanjaName: "金哲洙" })
+    if (result.status !== "ok") {
+      // 한자 데이터에 哲,洙가 없을 수 있으므로 unknown-stroke도 허용
+      expect(["ok", "unknown-stroke"]).toContain(result.status)
+      return
+    }
+    expect(result.result.split.surname).toBe("김")
+    expect(result.result.split.givenName).toBe("철수")
+    expect(result.result.strokes.perSyllable).toHaveLength(3)
+    expect(result.result.grids.jeong).toBe(result.result.strokes.total)
+  })
+})
+
+describe("generateNameInterpretation", () => {
+  it("해석 문장을 생성한다", () => {
+    const result = generateNameInterpretation({
+      split: { surname: "김", givenName: "철수", surnameLength: 1, givenNameLength: 2 },
+      strokes: { perSyllable: [8, 10, 10], surname: 8, givenName: 20, total: 28 },
+      grids: { won: 18, hyung: 18, yi: 20, jeong: 28 },
+      interpretations: {
+        won: "안정과 성실이 돋보입니다",
+        hyung: "안정과 성실이 돋보입니다",
+        yi: "도전과 성취의 기운이 있습니다",
+        jeong: "도전과 성취의 기운이 있습니다",
+        overall: "균형감이 좋습니다",
+      },
+    })
+    expect(result).toContain("김")
+    expect(result).toContain("철수")
+    expect(result).toContain("28획")
+    expect(result).toContain("성명학 해석은 참고용")
+  })
+})

--- a/src/features/analysis/vark/__tests__/vark-scoring.test.ts
+++ b/src/features/analysis/vark/__tests__/vark-scoring.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import {
+  calculateProgress,
+  scoreVark,
+  determineVarkType,
+} from "../vark-scoring"
+import type { VarkQuestion, VarkPercentages } from "../vark-scoring"
+
+describe("calculateProgress", () => {
+  it("응답 수 기반 진행률을 계산한다", () => {
+    expect(calculateProgress({ "1": 3, "2": 4 }, 8)).toEqual({
+      answeredCount: 2,
+      totalQuestions: 8,
+      percentage: 25,
+    })
+  })
+})
+
+describe("determineVarkType", () => {
+  it("하나의 유형이 지배적이면 해당 유형을 반환한다", () => {
+    const p: VarkPercentages = { V: 50, A: 20, R: 15, K: 15 }
+    expect(determineVarkType(p)).toBe("V")
+  })
+
+  it("두 유형이 지배적이면 두 글자 조합을 반환한다", () => {
+    const p: VarkPercentages = { V: 35, A: 35, R: 15, K: 15 }
+    expect(determineVarkType(p)).toBe("VA")
+  })
+
+  it("모든 유형이 고르면 VARK를 반환한다", () => {
+    const p: VarkPercentages = { V: 25, A: 25, R: 25, K: 25 }
+    expect(determineVarkType(p)).toBe("VARK")
+  })
+
+  it("4개 모두 threshold+margin 이상이면 VARK를 반환한다", () => {
+    const p: VarkPercentages = { V: 29, A: 29, R: 29, K: 13 }
+    // V,A,R >= 28 (25+3), K < 28 → VRA 가 아닌 확인
+    expect(determineVarkType(p)).toBe("VAR")
+  })
+
+  it("지배적인 유형 없이 모두 threshold 미만이면 VARK를 반환한다", () => {
+    const p: VarkPercentages = { V: 27, A: 27, R: 27, K: 19 }
+    // 27 < 28(25+3)이므로 모두 미달 → VARK
+    expect(determineVarkType(p)).toBe("VARK")
+  })
+})
+
+describe("scoreVark", () => {
+  const questions: VarkQuestion[] = [
+    { id: 1, type: "V", text: "Q1", description: "" },
+    { id: 2, type: "A", text: "Q2", description: "" },
+    { id: 3, type: "R", text: "Q3", description: "" },
+    { id: 4, type: "K", text: "Q4", description: "" },
+  ]
+
+  it("점수를 올바르게 집계한다", () => {
+    const responses = { "1": 5, "2": 3, "3": 4, "4": 2 }
+    const result = scoreVark(responses, questions)
+    expect(result.scores).toEqual({ v: 5, a: 3, r: 4, k: 2 })
+  })
+
+  it("퍼센티지 합이 100이다", () => {
+    const responses = { "1": 5, "2": 3, "3": 4, "4": 2 }
+    const result = scoreVark(responses, questions)
+    const sum = result.percentages.V + result.percentages.A +
+      result.percentages.R + result.percentages.K
+    expect(sum).toBe(100)
+  })
+
+  it("응답이 없으면 균등 퍼센티지를 반환한다", () => {
+    const result = scoreVark({}, questions)
+    expect(result.percentages).toEqual({ V: 25, A: 25, R: 25, K: 25 })
+    expect(result.varkType).toBe("VARK")
+  })
+})

--- a/src/lib/chat/__tests__/parse-mention-chips.test.ts
+++ b/src/lib/chat/__tests__/parse-mention-chips.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest"
+import { parseMentionChips } from "../parse-mention-chips"
+import type { MentionedEntity } from "../mention-types"
+
+const student: MentionedEntity = {
+  id: "s1",
+  type: "student",
+  displayName: "홍길동",
+}
+
+const teacher: MentionedEntity = {
+  id: "t1",
+  type: "teacher",
+  displayName: "김선생",
+}
+
+describe("parseMentionChips", () => {
+  it("entities가 없으면 전체를 text 세그먼트로 반환한다", () => {
+    const result = parseMentionChips("안녕하세요", null)
+    expect(result).toEqual([{ kind: "text", text: "안녕하세요" }])
+  })
+
+  it("빈 entities 배열도 text로 처리한다", () => {
+    const result = parseMentionChips("텍스트", [])
+    expect(result).toEqual([{ kind: "text", text: "텍스트" }])
+  })
+
+  it("@멘션을 mention 세그먼트로 변환한다", () => {
+    const result = parseMentionChips("@홍길동 학생의 성적", [student])
+    expect(result).toEqual([
+      { kind: "mention", entity: student },
+      { kind: "text", text: " 학생의 성적" },
+    ])
+  })
+
+  it("여러 멘션을 처리한다", () => {
+    const result = parseMentionChips(
+      "@홍길동과 @김선생의 궁합",
+      [student, teacher]
+    )
+    expect(result).toHaveLength(4)
+    expect(result[0]).toEqual({ kind: "mention", entity: student })
+    expect(result[1]).toEqual({ kind: "text", text: "과 " })
+    expect(result[2]).toEqual({ kind: "mention", entity: teacher })
+    expect(result[3]).toEqual({ kind: "text", text: "의 궁합" })
+  })
+
+  it("멘션이 텍스트 끝에 있는 경우", () => {
+    const result = parseMentionChips("분석 대상: @홍길동", [student])
+    expect(result).toEqual([
+      { kind: "text", text: "분석 대상: " },
+      { kind: "mention", entity: student },
+    ])
+  })
+
+  it("@가 없는 이름은 매칭하지 않는다", () => {
+    const result = parseMentionChips("홍길동 학생", [student])
+    expect(result).toEqual([{ kind: "text", text: "홍길동 학생" }])
+  })
+})

--- a/src/lib/errors/__tests__/action-result.test.ts
+++ b/src/lib/errors/__tests__/action-result.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest"
+import { ok, okVoid, fail, fieldError, isOk, isFieldError } from "../action-result"
+
+describe("ActionResult 헬퍼", () => {
+  describe("ok", () => {
+    it("데이터 포함 성공 결과를 생성한다", () => {
+      const result = ok({ id: "1", name: "테스트" })
+      expect(result).toEqual({ success: true, data: { id: "1", name: "테스트" } })
+    })
+  })
+
+  describe("okVoid", () => {
+    it("데이터 없는 성공 결과를 생성한다", () => {
+      expect(okVoid()).toEqual({ success: true })
+    })
+
+    it("data 프로퍼티가 없다", () => {
+      expect(okVoid()).not.toHaveProperty("data")
+    })
+  })
+
+  describe("fail", () => {
+    it("에러 메시지를 포함한 실패 결과를 생성한다", () => {
+      expect(fail("에러 발생")).toEqual({ success: false, error: "에러 발생" })
+    })
+
+    it("에러 코드를 선택적으로 포함한다", () => {
+      expect(fail("인증 실패", "UNAUTHORIZED")).toEqual({
+        success: false,
+        error: "인증 실패",
+        code: "UNAUTHORIZED",
+      })
+    })
+
+    it("코드 없이 호출하면 code 프로퍼티가 없다", () => {
+      expect(fail("에러")).not.toHaveProperty("code")
+    })
+  })
+
+  describe("fieldError", () => {
+    it("필드 에러를 생성한다", () => {
+      const result = fieldError({ email: ["올바른 이메일을 입력하세요"] })
+      expect(result).toEqual({
+        success: false,
+        fieldErrors: { email: ["올바른 이메일을 입력하세요"] },
+      })
+    })
+
+    it("전체 에러 메시지를 선택적으로 포함한다", () => {
+      const result = fieldError(
+        { name: ["필수 입력입니다"] },
+        "입력값이 잘못되었습니다"
+      )
+      expect(result.error).toBe("입력값이 잘못되었습니다")
+      expect(result.fieldErrors).toEqual({ name: ["필수 입력입니다"] })
+    })
+  })
+})
+
+describe("타입 가드", () => {
+  describe("isOk", () => {
+    it("성공 결과에 true를 반환한다", () => {
+      expect(isOk(ok("데이터"))).toBe(true)
+      expect(isOk(okVoid())).toBe(true)
+    })
+
+    it("실패 결과에 false를 반환한다", () => {
+      expect(isOk(fail("에러"))).toBe(false)
+      expect(isOk(fieldError({ a: ["에러"] }))).toBe(false)
+    })
+  })
+
+  describe("isFieldError", () => {
+    it("필드 에러에 true를 반환한다", () => {
+      expect(isFieldError(fieldError({ a: ["에러"] }))).toBe(true)
+    })
+
+    it("일반 실패에 false를 반환한다", () => {
+      expect(isFieldError(fail("에러"))).toBe(false)
+    })
+
+    it("성공 결과에 false를 반환한다", () => {
+      expect(isFieldError(ok("데이터"))).toBe(false)
+    })
+  })
+})

--- a/src/shared/utils/__tests__/date-range.test.ts
+++ b/src/shared/utils/__tests__/date-range.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { getDateRangeFromPreset, PRESET_LABELS, DEFAULT_PRESETS } from "../date-range"
+
+describe("getDateRangeFromPreset", () => {
+  beforeEach(() => {
+    // 2025-06-15 12:00:00 KST (03:00 UTC) 고정
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2025-06-15T03:00:00.000Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("TODAY: 오늘의 시작~끝을 반환한다", () => {
+    const range = getDateRangeFromPreset("TODAY")
+    expect(range.start.getDate()).toBe(range.end.getDate())
+    expect(range.start.getHours()).toBe(0)
+    expect(range.start.getMinutes()).toBe(0)
+  })
+
+  it("7D: 7일 전부터 오늘까지 범위를 반환한다", () => {
+    const range = getDateRangeFromPreset("7D")
+    const diffMs = range.end.getTime() - range.start.getTime()
+    const diffDays = diffMs / (1000 * 60 * 60 * 24)
+    // startOfDay(7일 전) ~ endOfDay(오늘)이므로 약 7일 + α
+    expect(diffDays).toBeGreaterThanOrEqual(7)
+    expect(diffDays).toBeLessThan(8.1)
+  })
+
+  it("30D: 30일 범위를 반환한다", () => {
+    const range = getDateRangeFromPreset("30D")
+    const diffMs = range.end.getTime() - range.start.getTime()
+    const diffDays = diffMs / (1000 * 60 * 60 * 24)
+    expect(diffDays).toBeGreaterThanOrEqual(30)
+    expect(diffDays).toBeLessThan(31.1)
+  })
+
+  it("1M: 이번 달 시작~끝을 반환한다", () => {
+    const range = getDateRangeFromPreset("1M")
+    // 1M = 현재 달(subMonths(now, 0))의 startOfMonth ~ endOfMonth(now)
+    expect(range.start.getMonth()).toBe(5) // June (0-indexed)
+    expect(range.end.getMonth()).toBe(5)
+  })
+
+  it("3M: 3개월 범위를 반환한다", () => {
+    const range = getDateRangeFromPreset("3M")
+    // 2025-06에서 3M = subMonths(6, 2) = 4월부터
+    expect(range.start.getMonth()).toBe(3) // April
+    expect(range.end.getMonth()).toBe(5) // June
+  })
+
+  it("ALL: 2020-01-01부터 시작한다", () => {
+    const range = getDateRangeFromPreset("ALL")
+    expect(range.start.getFullYear()).toBe(2020)
+    expect(range.start.getMonth()).toBe(0)
+    expect(range.start.getDate()).toBe(1)
+  })
+
+  it("start가 항상 end보다 이전이다", () => {
+    const presets = ["TODAY", "7D", "30D", "1M", "3M", "6M", "1Y", "ALL"] as const
+    for (const preset of presets) {
+      const range = getDateRangeFromPreset(preset)
+      expect(range.start.getTime()).toBeLessThanOrEqual(range.end.getTime())
+    }
+  })
+})
+
+describe("PRESET_LABELS", () => {
+  it("모든 프리셋에 한국어 레이블이 있다", () => {
+    expect(PRESET_LABELS.TODAY).toBe("오늘")
+    expect(PRESET_LABELS["7D"]).toBe("최근 7일")
+    expect(PRESET_LABELS.ALL).toBe("전체")
+  })
+})
+
+describe("DEFAULT_PRESETS", () => {
+  it("기본 프리셋 목록이 올바르다", () => {
+    expect(DEFAULT_PRESETS).toEqual(["TODAY", "7D", "30D", "3M", "ALL"])
+  })
+})

--- a/src/shared/utils/__tests__/extract-json.test.ts
+++ b/src/shared/utils/__tests__/extract-json.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest"
+import { extractJsonFromLLM } from "../extract-json"
+
+describe("extractJsonFromLLM", () => {
+  // 1단계: 순수 JSON 직접 파싱
+  it("순수 JSON 문자열을 파싱한다", () => {
+    const json = '{"name":"홍길동","score":95}'
+    expect(extractJsonFromLLM(json)).toEqual({ name: "홍길동", score: 95 })
+  })
+
+  it("앞뒤 공백이 있어도 파싱한다", () => {
+    expect(extractJsonFromLLM("  { \"a\": 1 }  ")).toEqual({ a: 1 })
+  })
+
+  // 2단계: 마크다운 코드블록
+  it("```json 코드블록에서 JSON을 추출한다", () => {
+    const text = '분석 결과:\n```json\n{"result": "success"}\n```\n위와 같습니다.'
+    expect(extractJsonFromLLM(text)).toEqual({ result: "success" })
+  })
+
+  it("``` 코드블록(언어 미지정)에서도 추출한다", () => {
+    const text = '```\n{"key": "value"}\n```'
+    expect(extractJsonFromLLM(text)).toEqual({ key: "value" })
+  })
+
+  // 3단계: 텍스트 속 JSON 객체 추출
+  it("설명 텍스트 사이에 있는 JSON 객체를 추출한다", () => {
+    const text = '결과는 다음과 같습니다: {"score": 42, "level": "high"} 위 점수를 참고하세요.'
+    expect(extractJsonFromLLM(text)).toEqual({ score: 42, level: "high" })
+  })
+
+  it("중첩된 JSON 객체도 올바르게 추출한다", () => {
+    const text = '응답: {"outer": {"inner": 123}, "list": [1,2,3]}'
+    expect(extractJsonFromLLM(text)).toEqual({ outer: { inner: 123 }, list: [1, 2, 3] })
+  })
+
+  it("문자열 안의 중괄호를 올바르게 처리한다", () => {
+    const text = '분석: {"text": "값은 {x}입니다", "count": 1}'
+    expect(extractJsonFromLLM(text)).toEqual({ text: "값은 {x}입니다", count: 1 })
+  })
+
+  it("이스케이프된 따옴표를 처리한다", () => {
+    const text = '{"msg": "He said \\"hello\\"", "ok": true}'
+    expect(extractJsonFromLLM(text)).toEqual({ msg: 'He said "hello"', ok: true })
+  })
+
+  // 실패 케이스
+  it("JSON이 없으면 에러를 던진다", () => {
+    expect(() => extractJsonFromLLM("그냥 텍스트입니다.")).toThrow(
+      "LLM 응답에서 유효한 JSON을 추출할 수 없습니다"
+    )
+  })
+
+  it("빈 문자열에서 에러를 던진다", () => {
+    expect(() => extractJsonFromLLM("")).toThrow()
+  })
+})

--- a/src/shared/utils/__tests__/pagination.test.ts
+++ b/src/shared/utils/__tests__/pagination.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest"
+import {
+  normalizePaginationParams,
+  getPrismaSkipTake,
+  buildPaginatedResult,
+} from "../pagination"
+
+describe("normalizePaginationParams", () => {
+  it("기본값을 반환한다 (파라미터 없음)", () => {
+    expect(normalizePaginationParams()).toEqual({ page: 1, pageSize: 20 })
+  })
+
+  it("전달된 값을 그대로 사용한다", () => {
+    expect(normalizePaginationParams({ page: 3, pageSize: 10 })).toEqual({
+      page: 3,
+      pageSize: 10,
+    })
+  })
+
+  it("page가 0 이하이면 1로 보정한다", () => {
+    expect(normalizePaginationParams({ page: 0 })).toEqual({ page: 1, pageSize: 20 })
+    expect(normalizePaginationParams({ page: -5 })).toEqual({ page: 1, pageSize: 20 })
+  })
+
+  it("pageSize가 MAX(100)를 초과하면 100으로 제한한다", () => {
+    expect(normalizePaginationParams({ pageSize: 200 })).toEqual({
+      page: 1,
+      pageSize: 100,
+    })
+  })
+
+  it("소수점을 버린다 (floor)", () => {
+    expect(normalizePaginationParams({ page: 2.7, pageSize: 15.9 })).toEqual({
+      page: 2,
+      pageSize: 15,
+    })
+  })
+})
+
+describe("getPrismaSkipTake", () => {
+  it("1페이지의 skip/take를 계산한다", () => {
+    expect(getPrismaSkipTake({ page: 1, pageSize: 20 })).toEqual({
+      skip: 0,
+      take: 20,
+    })
+  })
+
+  it("3페이지의 skip/take를 계산한다", () => {
+    expect(getPrismaSkipTake({ page: 3, pageSize: 10 })).toEqual({
+      skip: 20,
+      take: 10,
+    })
+  })
+})
+
+describe("buildPaginatedResult", () => {
+  it("페이지네이션 결과를 올바르게 생성한다", () => {
+    const result = buildPaginatedResult(["a", "b", "c"], 25, {
+      page: 1,
+      pageSize: 10,
+    })
+    expect(result).toEqual({
+      data: ["a", "b", "c"],
+      total: 25,
+      page: 1,
+      pageSize: 10,
+      totalPages: 3,
+    })
+  })
+
+  it("total이 0이면 totalPages도 0이다", () => {
+    const result = buildPaginatedResult([], 0, { page: 1, pageSize: 10 })
+    expect(result.totalPages).toBe(0)
+  })
+
+  it("나머지가 있으면 totalPages를 올림한다", () => {
+    const result = buildPaginatedResult([], 21, { page: 1, pageSize: 10 })
+    expect(result.totalPages).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
- 0개 → 90개 단위 테스트 추가 (10개 파일, 738줄)
- 테스트 대상: 프로젝트 핵심 순수 함수 10개 모듈
- 실행 시간: ~1초 (vitest)

## 테스트 커버리지

| 모듈 | 테스트 수 | 주요 검증 |
|------|-----------|----------|
| `extract-json` | 10 | LLM JSON 파싱 3단계 폴백 |
| `pagination` | 10 | 파라미터 정규화, skip/take, totalPages |
| `date-range` | 9 | 프리셋 날짜 범위 (fakeTimers) |
| `action-result` | 13 | ok/fail/fieldError 헬퍼 + 타입 가드 |
| `saju-utils` | 9 | 한자 변환, 생시 포맷 |
| `parse-mention-chips` | 6 | @멘션 파싱, 구형 메시지 호환 |
| `mbti-scoring` | 8 | 4차원 점수 집계, 동점 처리 |
| `vark-scoring` | 9 | VARK 유형 판정, 퍼센티지 보정 |
| `name-numerology` | 11 | 복성 이름 분리, 성명학 계산 |
| `compatibility-scoring` | 5 | 궁합 breakdown 합산 검증 |

## Test plan
- [x] `pnpm run test` — 90 passed, 0 failed
- [x] 기존 typecheck/lint 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)