### PR TITLE
fix: 채팅 시스템 코드 리뷰 지적사항 반영

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -104,23 +104,23 @@ export async function POST(request: Request) {
       ];
     }
 
-    // user 메시지 DB 저장
-    await db.chatMessage.create({
-      data: {
-        sessionId: chatSessionId,
-        role: 'user',
-        content: trimmedPrompt,
-        mentionedEntities: mentionedEntitiesData
-          ? (mentionedEntitiesData as import('@/lib/db').Prisma.InputJsonValue)
-          : undefined,
-      },
-    });
-
-    // 세션 updatedAt 갱신
-    await db.chatSession.update({
-      where: { id: chatSessionId },
-      data: { updatedAt: new Date() },
-    });
+    // user 메시지 DB 저장 + 세션 updatedAt 갱신 (독립적이므로 병렬 실행)
+    await Promise.all([
+      db.chatMessage.create({
+        data: {
+          sessionId: chatSessionId,
+          role: 'user',
+          content: trimmedPrompt,
+          mentionedEntities: mentionedEntitiesData
+            ? (mentionedEntitiesData as import('@/lib/db').Prisma.InputJsonValue)
+            : undefined,
+        },
+      }),
+      db.chatSession.update({
+        where: { id: chatSessionId },
+        data: { updatedAt: new Date() },
+      }),
+    ]);
 
     // auto 모드
     let effectiveProviderId = providerId || undefined;

--- a/src/lib/chat/auto-detect.ts
+++ b/src/lib/chat/auto-detect.ts
@@ -1,13 +1,6 @@
 import 'server-only'
 import { db } from '@/lib/db/client'
-import type { TeacherRole } from '@/lib/db/common/rbac'
-import type { MentionItem } from './mention-types'
-
-type Session = {
-  userId: string
-  role: TeacherRole
-  teamId: string | null
-}
+import type { MentionItem, ChatSession } from './mention-types'
 
 type EntityCacheEntry = {
   students: Array<{ id: string; name: string; teamId: string | null }>
@@ -17,10 +10,26 @@ type EntityCacheEntry = {
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5분
+const CACHE_MAX_SIZE = 100 // 최대 캐시 엔트리 수 (메모리 누수 방지)
+const MAX_AUTO_DETECTED = 5 // 자동 감지 최대 엔티티 수 (false positive 제한)
 // 인메모리 캐시: standalone 단일 프로세스 전제. 학생 추가/삭제는 TTL 만료 후 반영됨.
 const entityCache = new Map<string, EntityCacheEntry>()
 
-async function getEntityNames(session: Session): Promise<Omit<EntityCacheEntry, 'expiry'>> {
+/** 만료된 엔트리를 정리하고, 크기 제한 초과 시 가장 오래된 엔트리부터 제거 */
+function evictStaleEntries() {
+  const now = Date.now()
+  for (const [key, entry] of entityCache) {
+    if (entry.expiry <= now) entityCache.delete(key)
+  }
+  // 크기 초과 시 삽입 순서상 가장 오래된 엔트리 제거 (Map은 삽입 순서 보장)
+  while (entityCache.size >= CACHE_MAX_SIZE) {
+    const oldest = entityCache.keys().next().value
+    if (oldest) entityCache.delete(oldest)
+    else break
+  }
+}
+
+async function getEntityNames(session: ChatSession): Promise<Omit<EntityCacheEntry, 'expiry'>> {
   const cacheKey = `entities:${session.userId}`
   const cached = entityCache.get(cacheKey)
   if (cached && cached.expiry > Date.now()) {
@@ -41,6 +50,7 @@ async function getEntityNames(session: Session): Promise<Omit<EntityCacheEntry, 
     }),
   ])
 
+  evictStaleEntries()
   const entry: EntityCacheEntry = {
     students,
     teachers,
@@ -59,7 +69,7 @@ async function getEntityNames(session: Session): Promise<Omit<EntityCacheEntry, 
  */
 export async function autoDetectEntities(
   message: string,
-  session: Session,
+  session: ChatSession,
   existingMentions: MentionItem[]
 ): Promise<MentionItem[]> {
   const entities = await getEntityNames(session)
@@ -100,5 +110,5 @@ export async function autoDetectEntities(
     detected.push({ type: 'team', id: team.id })
   }
 
-  return detected
+  return detected.slice(0, MAX_AUTO_DETECTED)
 }

--- a/src/lib/chat/mention-resolver.ts
+++ b/src/lib/chat/mention-resolver.ts
@@ -2,21 +2,13 @@ import 'server-only'
 import { db } from '@/lib/db/client'
 import { logger } from '@/lib/logger'
 import { logAuditAction } from '@/lib/dal'
-import type { TeacherRole } from '@/lib/db/common/rbac'
 import type {
   MentionItem,
   ResolvedMention,
   MentionedEntity,
   MentionResolutionResult,
+  ChatSession,
 } from './mention-types'
-
-// ─── 타입 헬퍼 ────────────────────────────────────────────────────────────────
-
-interface Session {
-  userId: string
-  role: TeacherRole
-  teamId: string | null
-}
 
 // ─── 텍스트 축약 헬퍼 ─────────────────────────────────────────────────────────
 
@@ -240,7 +232,7 @@ async function handleAccessDenied(params: {
 
 async function resolveStudents(
   studentIds: string[],
-  session: Session
+  session: ChatSession
 ): Promise<{
   resolved: ResolvedMention[]
   metadata: MentionedEntity[]
@@ -412,7 +404,7 @@ async function resolveStudents(
 
 async function resolveTeachers(
   teacherIds: string[],
-  session: Session
+  session: ChatSession
 ): Promise<{
   resolved: ResolvedMention[]
   metadata: MentionedEntity[]
@@ -562,7 +554,7 @@ async function resolveTeachers(
 
 async function resolveTeams(
   teamIds: string[],
-  session: Session
+  session: ChatSession
 ): Promise<{
   resolved: ResolvedMention[]
   metadata: MentionedEntity[]
@@ -671,7 +663,7 @@ async function resolveTeams(
  */
 export async function resolveMentions(
   mentions: MentionItem[],
-  session: Session
+  session: ChatSession
 ): Promise<MentionResolutionResult> {
   if (mentions.length === 0) {
     return { resolved: [], metadata: [], accessDeniedMessages: [] }

--- a/src/lib/chat/mention-types.ts
+++ b/src/lib/chat/mention-types.ts
@@ -1,5 +1,14 @@
 // 멘션 시스템 공유 타입 — Phase 36~40에서 사용
 
+import type { TeacherRole } from '@/lib/db/common/rbac'
+
+/** 채팅 시스템 전역 세션 타입 (auto-detect, tools, mention-resolver 공유) */
+export type ChatSession = {
+  userId: string
+  role: TeacherRole
+  teamId: string | null
+}
+
 /**
  * 멘션 가능한 엔티티 타입
  * - student: 학생

--- a/src/lib/chat/tools.ts
+++ b/src/lib/chat/tools.ts
@@ -2,30 +2,24 @@ import 'server-only'
 import { tool } from 'ai'
 import { z } from 'zod'
 import { db } from '@/lib/db/client'
-import type { TeacherRole } from '@/lib/db/common/rbac'
+import type { ChatSession } from './mention-types'
 
-type Session = {
-  userId: string
-  role: TeacherRole
-  teamId: string | null
-}
-
-function studentWhere(session: Session) {
+function studentWhere(session: ChatSession) {
   if (session.role === 'DIRECTOR') return {}
   return { teamId: session.teamId }
 }
 
-function teacherWhere(session: Session) {
+function teacherWhere(session: ChatSession) {
   if (session.role === 'DIRECTOR') return {}
   return { teamId: session.teamId }
 }
 
-export function createChatTools(session: Session) {
+export function createChatTools(session: ChatSession) {
   return {
     searchStudents: tool({
       description: '이름, 학교, 학년으로 학생을 검색합니다. 최대 10건 반환.',
       inputSchema: z.object({
-        query: z.string().describe('검색어 (학생 이름, 학교명 등)'),
+        query: z.string().min(1).describe('검색어 (학생 이름, 학교명 등)'),
         school: z.string().optional().describe('학교명 필터'),
         grade: z.number().optional().describe('학년 필터'),
       }),
@@ -75,7 +69,7 @@ export function createChatTools(session: Session) {
     searchTeachers: tool({
       description: '이름, 역할로 선생님을 검색합니다.',
       inputSchema: z.object({
-        query: z.string().describe('검색어 (선생님 이름)'),
+        query: z.string().min(1).describe('검색어 (선생님 이름)'),
         role: z.string().optional().describe('역할 필터 (DIRECTOR, TEAM_LEADER, TEACHER 등)'),
       }),
       execute: async ({ query, role }) => {

--- a/src/lib/validations/chat.ts
+++ b/src/lib/validations/chat.ts
@@ -10,7 +10,7 @@ export const ChatRequestSchema = z.object({
     content: z.string(),
   })).optional(),
   mentions: z.array(z.object({
-    type: z.string(),
+    type: z.enum(['student', 'teacher', 'team']),
     id: z.string(),
     name: z.string().optional(),
   }).passthrough()).optional(),


### PR DESCRIPTION
## Summary
- 인메모리 캐시 크기 제한(100) + TTL 만료 엔트리 정리로 메모리 누수 방지
- 자동 감지 결과 최대 5개 제한으로 false positive 억제
- `Session` 타입 3중 중복 → `ChatSession`으로 `mention-types.ts`에 통합
- `searchStudents`/`searchTeachers` 빈 쿼리 방어 (`z.string().min(1)`)
- `mentions.type` 검증 `z.string()` → `z.enum(['student','teacher','team'])`
- DB 저장(`chatMessage.create` + `chatSession.update`) `Promise.all` 병렬화

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] Vitest 전체 테스트 290개 통과 (24 파일)
- [ ] 채팅에서 학생 이름 자동 감지 동작 확인
- [ ] 빈 검색어로 Tool Use 호출 시 에러 반환 확인
- [ ] 6명 이상 학생 이름 포함 메시지에서 최대 5명만 감지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)