### PR TITLE
chore: prisma migrate 워크플로우 정착 + CI drift 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,36 @@ jobs:
         env:
           DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
 
+      - name: Check Prisma schema/migrations drift
+        env:
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
+        run: |
+          set +e
+          OUTPUT=$(pnpm dlx prisma migrate diff \
+            --from-migrations prisma/migrations \
+            --to-schema-datamodel prisma/schema.prisma \
+            --exit-code 2>&1)
+          STATUS=$?
+          set -e
+
+          if [ $STATUS -eq 0 ]; then
+            echo "::notice::Prisma schema와 migrations가 일치합니다."
+          elif [ $STATUS -eq 2 ]; then
+            echo "::error::Prisma schema와 migrations 불일치 (drift 감지)."
+            echo "schema.prisma에 모델을 추가/수정 후 마이그레이션 파일이 누락된 것으로 보입니다."
+            echo ""
+            echo "해결: 로컬에서 'pnpm prisma migrate dev --name <설명>' 실행 후"
+            echo "      생성된 prisma/migrations/* 파일을 커밋하세요."
+            echo ""
+            echo "drift 내용:"
+            printf '%s\n' "$OUTPUT"
+            exit 1
+          else
+            echo "::error::Prisma migrate diff 실행 실패 (exit code: $STATUS)"
+            printf '%s\n' "$OUTPUT"
+            exit 1
+          fi
+
       - name: Lint
         run: pnpm run lint
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,10 +104,32 @@ export async function myAction(input: string): Promise<ActionResult<MyType>> {
 
 ### DB 스키마 변경
 
+**원칙**: schema 변경은 반드시 마이그레이션 파일과 함께 커밋합니다. `db:push`는 production drift의 원인이 되므로 일상 워크플로우에서 사용하지 않습니다.
+
 ```bash
-# 스키마 수정 후
-pnpm db:push        # 개발 환경 반영
-pnpm db:generate    # 타입 재생성
+# 스키마 수정 후 (정식 워크플로우)
+pnpm prisma migrate dev --name <설명>   # 마이그레이션 파일 생성 + 적용 + 클라이언트 재생성
+git add prisma/schema.prisma prisma/migrations/  # 두 가지 모두 커밋
+
+# production 배포 시 (CI/CD)
+pnpm prisma migrate deploy   # 신규 마이그레이션만 적용 (idempotent)
+```
+
+#### `db:push` 사용 가능 상황 (예외)
+- **프로토타입 단계**: 모델 구조를 빠르게 실험할 때 (커밋 전)
+- **테스트 DB 초기화**: CI에서 일회성 schema 동기화
+
+`db:push`로 운영/스테이징 DB를 변경하면 `_prisma_migrations` 테이블과 schema가 어긋나며, 이후 `migrate deploy`가 P3018/P2021 에러로 실패합니다.
+
+#### Drift 검증
+PR에서 schema vs migrations 일치 여부를 자동 검증합니다 — `.github/workflows/ci.yml`의 "Check Prisma schema/migrations drift" step 참고.
+수동 확인:
+```bash
+pnpm prisma migrate diff \
+  --from-migrations prisma/migrations \
+  --to-schema-datamodel prisma/schema.prisma \
+  --exit-code
+# exit code 0 = 일치, 2 = drift 있음
 ```
 
 ## 핵심 인프라 파일
@@ -149,9 +171,12 @@ pnpm test             # Vitest 단위 테스트
 pnpm test:e2e         # Playwright E2E
 pnpm format           # Prettier 포맷팅
 pnpm format:check     # 포맷팅 체크
-pnpm db:generate      # Prisma 클라이언트 생성
-pnpm db:push          # 스키마 DB 반영
-pnpm db:seed          # 시드 데이터 (dotenv -e .env)
+pnpm db:generate                              # Prisma 클라이언트 생성
+pnpm prisma migrate dev --name <설명>          # ★ 마이그레이션 (정식 워크플로우)
+pnpm prisma migrate deploy                    # production 마이그레이션 적용 (CI/CD)
+pnpm prisma migrate status                    # 적용 상태 확인
+pnpm db:push                                  # ⚠️ 프로토타입 전용 (drift 위험, 일상 사용 금지)
+pnpm db:seed                                  # 시드 데이터 (dotenv -e .env)
 ```
 
 ## 상세 분석 문서


### PR DESCRIPTION
## Summary
- CLAUDE.md의 DB 스키마 변경 가이드를 `migrate dev` 중심으로 재작성
- CI(ci.yml)에 schema vs migrations drift 검증 step 추가
- `db:push` 사용 범위를 프로토타입/테스트 한정으로 축소

## 배경

production DB(`ais-postgres`)에서 schema와 실제 DB가 어긋나는 drift가 발견되어 수동 복구가 필요했습니다:

- **누락된 객체**: enum 11개 + 테이블 10개 (`agent_*`, `university_*`, `admission_*`, `NeuroscienceCache` 등)
- **증상**: ai-afterschool-fsd-web 컨테이너에서 `prisma:error P2021: The table 'public.agent_executions' does not exist` 반복 발생
- **원인 추정**: 마지막 마이그레이션(2026-02-27) 이후 schema에 모델은 추가됐지만 마이그레이션 파일은 생성되지 않은 채 PR이 머지됨. CLAUDE.md가 `pnpm db:push`를 정식 워크플로우로 안내한 영향이 큼.

## 변경 내용

### 1. CLAUDE.md
**Before** (문제 있던 안내):
```bash
pnpm db:push        # 개발 환경 반영
pnpm db:generate    # 타입 재생성
```

**After**:
```bash
# 정식 워크플로우
pnpm prisma migrate dev --name <설명>
git add prisma/schema.prisma prisma/migrations/

# production 배포 (CI/CD)
pnpm prisma migrate deploy
```

추가:
- `db:push` 사용 가능 상황을 프로토타입/테스트로 한정
- drift 발생 시 P3018/P2021 에러 가능성 명시
- 수동 drift 검증 방법 안내

### 2. `.github/workflows/ci.yml`

기존 `validate` job에 `Check Prisma schema/migrations drift` step 1개 추가:

```yaml
- name: Check Prisma schema/migrations drift
  env:
    DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
  run: |
    # prisma migrate diff로 schema와 migrations 일치 검증
    # drift 감지 시 PR 차단 + 해결 가이드 출력
    ...
```

- 위치: `Generate Prisma Client` 직후, `Lint` 이전 (빠르게 실패)
- exit code: 0=일치, 2=drift(차단), 그 외=실행 오류
- drift 감지 시 명확한 해결 가이드 출력

## 영향
- 향후 schema에만 변경하고 마이그레이션 파일을 누락한 PR은 자동 차단
- 일상 워크플로우 변경 (db:push → migrate dev): 개발자가 프로토타입 외에는 마이그레이션 파일 생성 필요
- CI 시간: drift 체크 step은 수 초 이내로 영향 미미

## 검증
- [x] YAML 유효성 통과
- [x] CLAUDE.md 마크다운 구조 유지
- [x] 기존 CI step 수정 없음 (drift 체크만 추가)
- [ ] 본 PR의 CI에서 drift 체크 step이 정상 작동하는지 확인 (현재 main과 일치하므로 PASS 예상)

## Test plan
- [ ] 본 PR의 CI 통과 (drift 체크 PASS 확인)
- [ ] 머지 후 다음 schema 변경 PR에서 워크플로우가 정상 작동하는지 모니터링
- [ ] (선택) 일부러 schema에만 모델 추가한 테스트 PR로 차단 동작 확인

## 관련 이슈
- 직전 PR #53: production 이미지에서 prisma 마이그레이션 가능하도록 dotenv/prisma를 dependencies로 이동
- 두 PR 모두 머지되면 향후 schema drift 발생 자체가 차단됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)